### PR TITLE
Add custom errors

### DIFF
--- a/sdk/metabase/client.go
+++ b/sdk/metabase/client.go
@@ -52,7 +52,8 @@ func (m *MetabaseAPIClient) request(ctx context.Context, path string, body any, 
 	if resp.StatusCode/100 != 2 {
 		defer resp.Body.Close()
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(bodyBytes))
+		message := string(bodyBytes)
+		return nil, CreateErrorFromStatusCode(resp.StatusCode, message)
 	}
 
 	return resp, nil

--- a/sdk/metabase/errors.go
+++ b/sdk/metabase/errors.go
@@ -1,0 +1,127 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package metabase
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// BaseError is the base error type for all domain-specific errors.
+type BaseError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *BaseError) Error() string {
+	return fmt.Sprintf("%s (status code: %d)", e.Message, e.StatusCode)
+}
+
+// NotFoundError is returned when a resource is not found (404).
+type NotFoundError struct {
+	BaseError
+}
+
+func NewNotFoundError(message string) *NotFoundError {
+	return &NotFoundError{
+		BaseError: BaseError{
+			StatusCode: http.StatusNotFound,
+			Message:    message,
+		},
+	}
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("Resource not found: %s", e.Message)
+}
+
+// ConflictError is returned when there's a conflict (409), e.g., resource already exists.
+type ConflictError struct {
+	BaseError
+	Details string
+}
+
+func NewConflictError(message string) *ConflictError {
+	return &ConflictError{
+		BaseError: BaseError{
+			StatusCode: http.StatusConflict,
+			Message:    message,
+		},
+	}
+}
+
+func (e *ConflictError) Error() string {
+	return fmt.Sprintf("Conflict: %s - %s", e.Details, e.Message)
+}
+
+// BadRequestError is returned for bad requests (400).
+type BadRequestError struct {
+	BaseError
+}
+
+func NewBadRequestError(message string) *BadRequestError {
+	return &BadRequestError{
+		BaseError: BaseError{
+			StatusCode: http.StatusBadRequest,
+			Message:    message,
+		},
+	}
+}
+
+func (e *BadRequestError) Error() string {
+	return fmt.Sprintf("Bad request: %s", e.Message)
+}
+
+// UnauthorizedError is returned for unauthorized requests (401).
+type UnauthorizedError struct {
+	BaseError
+}
+
+func NewUnauthorizedError(message string) *UnauthorizedError {
+	return &UnauthorizedError{
+		BaseError: BaseError{
+			StatusCode: http.StatusUnauthorized,
+			Message:    message,
+		},
+	}
+}
+
+// ForbiddenError is returned for forbidden requests (403).
+type ForbiddenError struct {
+	BaseError
+}
+
+func NewForbiddenError(message string) *ForbiddenError {
+	return &ForbiddenError{
+		BaseError: BaseError{
+			StatusCode: http.StatusForbidden,
+			Message:    message,
+		},
+	}
+}
+
+func (e *ForbiddenError) Error() string {
+	return fmt.Sprintf("Access forbidden: %s", e.Message)
+}
+
+// CreateErrorFromStatusCode creates a domain-specific error based on the status code.
+func CreateErrorFromStatusCode(statusCode int, message string) error {
+	switch statusCode {
+	case http.StatusNotFound:
+		return NewNotFoundError(message)
+	case http.StatusConflict:
+		return NewConflictError(message)
+	case http.StatusBadRequest:
+		return NewBadRequestError(message)
+	case http.StatusUnauthorized:
+		return NewUnauthorizedError(message)
+	case http.StatusForbidden:
+		return NewForbiddenError(message)
+	default:
+		return &BaseError{
+			StatusCode: statusCode,
+			Message:    message,
+		}
+	}
+}

--- a/sdk/metabase/repositories/user_permission_group_membership.go
+++ b/sdk/metabase/repositories/user_permission_group_membership.go
@@ -39,7 +39,7 @@ func (r *UserPermissionGroupMembershipRepository) Create(ctx context.Context, us
 		}
 	}
 
-	return nil, fmt.Errorf("no membership found for user_id %s and group_id %s", userId, groupId)
+	return nil, metabase.NewNotFoundError(fmt.Sprintf("Membership not found for user_id %s and group_id %s", userId, groupId))
 
 }
 
@@ -64,7 +64,7 @@ func (r *UserPermissionGroupMembershipRepository) Get(ctx context.Context, id st
 			}
 		}
 	}
-	return nil, fmt.Errorf("membership with ID %s not found", id)
+	return nil, metabase.NewNotFoundError(fmt.Sprintf("Membership with ID %s not found", id))
 }
 
 func (r *UserPermissionGroupMembershipRepository) Delete(ctx context.Context, id string) error {


### PR DESCRIPTION
This pull request introduces enhanced error handling for the Metabase SDK by creating domain-specific error types and integrating them across the codebase. The changes improve code clarity, maintainability, and the ability to handle specific error cases more effectively. Key updates include the addition of a new error handling module, updates to existing methods to use these error types, and comprehensive test coverage for the new functionality.

### Error Handling Enhancements:
* Added a new `errors.go` file defining domain-specific error types such as `NotFoundError`, `ConflictError`, `BadRequestError`, `UnauthorizedError`, and `ForbiddenError`, all derived from a base `BaseError` type. Also included a helper function `CreateErrorFromStatusCode` to map HTTP status codes to these error types.

* Updated the `request` method in `MetabaseAPIClient` to utilize `CreateErrorFromStatusCode` for generating specific error instances based on HTTP response status codes.

### Repository Method Updates:
* Refactored methods in `UserPermissionGroupMembershipRepository` (`Create` and `Get`) to return `NotFoundError` instead of generic error messages when a membership is not found. [[1]](diffhunk://#diff-aefc51e68172a2079046e6ec25dca0d884f3d6af1b01b4841522827d2a5f2bb3L42-R42) [[2]](diffhunk://#diff-aefc51e68172a2079046e6ec25dca0d884f3d6af1b01b4841522827d2a5f2bb3L67-R67)

### Test Coverage:
* Added a new test `TestMetabaseAPIClient_ErrorHandling` to validate that the correct error types are returned for various HTTP status codes, ensuring robust error handling.